### PR TITLE
TASK: Include Routing through Settings.yaml

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -1,0 +1,6 @@
+TYPO3:
+  Flow:
+    mvc:
+      routes:
+        'TYPO3.Welcome':
+          position: 'start'


### PR DESCRIPTION
To avoid the message of 

`The SubRoute Package "TYPO3.Welcome" referenced in Route "Welcome" is not available.`

when using the default `Routes.yaml` from TYPO3.Flow this change moves the inclusion of the routes to the Settings.yaml

Ref neos/flow-development-collection#698