### PR TITLE
TASK: Use PackageManager, not PackageManagerInterface

### DIFF
--- a/Classes/Controller/StandardController.php
+++ b/Classes/Controller/StandardController.php
@@ -19,7 +19,7 @@ use Neos\Flow\Annotations as Flow;
 class StandardController extends \Neos\Flow\Mvc\Controller\ActionController
 {
     /**
-     * @var \Neos\Flow\Package\PackageManagerInterface
+     * @var \Neos\Flow\Package\PackageManager
      * @Flow\Inject
      */
     protected $packageManager;


### PR DESCRIPTION
The PackageManagerInterface is deprecated and will be removed with
Flow 6.0.