### PR TITLE
TASK: Add hint on Fluid dependency

### DIFF
--- a/Resources/Private/Templates/Standard/Index.html
+++ b/Resources/Private/Templates/Standard/Index.html
@@ -97,6 +97,7 @@
                 </f:else>
             </f:if>
         </p>
+        <p>A small note at this point: When the Welcome Package is deleted, the Fluid template engine is also removed. If you want to continue using Fluid, you have to install it manually via composer.</p>
         </section>
 </main>
 


### PR DESCRIPTION
Since Flow no longer has a dependency on Fluid, it needs to be added
explicitly if it is to be used. This changes adds a hint on that to the
Welcome package.

Fixes #19 